### PR TITLE
improve application configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,4 +98,4 @@ target/
 build/
 
 # local configuration
-config/custom.toml
+config/config.toml

--- a/.gitignore
+++ b/.gitignore
@@ -98,4 +98,4 @@ target/
 build/
 
 # local configuration
-config/local.toml
+config/custom.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,6 @@ EXPOSE 50051 9990
 # copy the raw binary into the new image
 COPY --from=builder "/usr/src/xenos/target/release/xenos" "/xenos"
 
-# copy the config into the new image (updating its location for kubernetes)
-COPY "./config" "/config/default"
-ENV CONFIG_DEFAULT_FILE=config/default/default
-
 # copy the users and groups for the nobody user and group
 COPY --from=builder "/etc/passwd" "/etc/passwd"
 COPY --from=builder "/etc/group" "/etc/group"

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,9 @@ EXPOSE 50051 9990
 # copy the raw binary into the new image
 COPY --from=builder "/usr/src/xenos/target/release/xenos" "/xenos"
 
-# copy the config into the new image
-COPY "./config" "/config"
+# copy the config into the new image (updating its location for kubernetes)
+COPY "./config" "/config/default"
+ENV CONFIG_DEFAULT_FILE=config/default/default
 
 # copy the users and groups for the nobody user and group
 COPY --from=builder "/etc/passwd" "/etc/passwd"

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -20,10 +20,6 @@ EXPOSE 50051 9990
 # copy the raw binary into the new image
 COPY --from=builder "/usr/src/xenos/target/release/xenos" "/xenos"
 
-# copy the config into the new image (updating its location for kubernetes)
-COPY "./config" "/config/default"
-ENV CONFIG_DEFAULT_FILE=config/default/default
-
 # copy the users and groups for the nobody user and group
 COPY --from=builder "/etc/passwd" "/etc/passwd"
 COPY --from=builder "/etc/group" "/etc/group"

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -20,8 +20,9 @@ EXPOSE 50051 9990
 # copy the raw binary into the new image
 COPY --from=builder "/usr/src/xenos/target/release/xenos" "/xenos"
 
-# copy the config into the new image
-COPY "./config" "/config"
+# copy the config into the new image (updating its location for kubernetes)
+COPY "./config" "/config/default"
+ENV CONFIG_DEFAULT_FILE=config/default/default
 
 # copy the users and groups for the nobody user and group
 COPY --from=builder "/etc/passwd" "/etc/passwd"

--- a/config/default.toml
+++ b/config/default.toml
@@ -3,32 +3,32 @@
 debug = false
 
 [cache.entries]
-uuid = {exp = "PT120M", exp_empty = "PT5M"}
-profile = {exp = "PT10M", exp_empty = "PT5M"}
-skin = {exp = "PT10M", exp_empty = "PT5M"}
-cape = {exp = "PT10M", exp_empty = "PT5M"}
-head = {exp = "PT10M", exp_empty = "PT5M"}
+uuid = { exp = "PT120M", exp_empty = "PT5M" }
+profile = { exp = "PT10M", exp_empty = "PT5M" }
+skin = { exp = "PT10M", exp_empty = "PT5M" }
+cape = { exp = "PT10M", exp_empty = "PT5M" }
+head = { exp = "PT10M", exp_empty = "PT5M" }
 
 [cache.redis]
 enabled = false
 address = "redis://username:password@example.com/0" # update if enabled
 
 [cache.redis.entries]
-uuid = {ttl = "P3D", ttl_empty = "P1D"}
-profile = {ttl = "P3D", ttl_empty = "P1D"}
-skin = {ttl = "P3D", ttl_empty = "P1D"}
-cape = {ttl = "P3D", ttl_empty = "P1D"}
-head = {ttl = "P3D", ttl_empty = "P1D"}
+uuid = { ttl = "P3D", ttl_empty = "P1D" }
+profile = { ttl = "P3D", ttl_empty = "P1D" }
+skin = { ttl = "P3D", ttl_empty = "P1D" }
+cape = { ttl = "P3D", ttl_empty = "P1D" }
+head = { ttl = "P3D", ttl_empty = "P1D" }
 
 [cache.moka]
 enabled = false
 
 [cache.moka.entries]
-uuid = {cap = 500, ttl = "PT1H", ttl_empty = "PT30M", tti = "PT1H", tti_empty = "PT30M"}
-profile = {cap = 300, ttl = "PT1H", ttl_empty = "PT30M", tti = "PT1H", tti_empty = "PT30M"}
-skin = {cap = 300, ttl = "PT1H", ttl_empty = "PT30M", tti = "PT1H", tti_empty = "PT30M"}
-cape = {cap = 300, ttl = "PT1H", ttl_empty = "PT30M", tti = "PT1H", tti_empty = "PT30M"}
-head = {cap = 300, ttl = "PT1H", ttl_empty = "PT30M", tti = "PT1H", tti_empty = "PT30M"}
+uuid = { cap = 500, ttl = "PT1H", ttl_empty = "PT30M", tti = "PT1H", tti_empty = "PT30M" }
+profile = { cap = 300, ttl = "PT1H", ttl_empty = "PT30M", tti = "PT1H", tti_empty = "PT30M" }
+skin = { cap = 300, ttl = "PT1H", ttl_empty = "PT30M", tti = "PT1H", tti_empty = "PT30M" }
+cape = { cap = 300, ttl = "PT1H", ttl_empty = "PT30M", tti = "PT1H", tti_empty = "PT30M" }
+head = { cap = 300, ttl = "PT1H", ttl_empty = "PT30M", tti = "PT1H", tti_empty = "PT30M" }
 
 [sentry]
 enabled = false
@@ -49,3 +49,6 @@ address = "0.0.0.0:9990"
 profile_enabled = true
 health_enabled = true
 address = "0.0.0.0:50051"
+
+[logging]
+level = "info"

--- a/config/default.toml
+++ b/config/default.toml
@@ -1,5 +1,7 @@
 # See settings documantation at src/settings.rs.
 
+unsigned_profile = true
+
 [cache.entries]
 uuid = { exp = "PT120M", exp_empty = "PT5M" }
 profile = { exp = "PT10M", exp_empty = "PT5M" }

--- a/config/default.toml
+++ b/config/default.toml
@@ -1,7 +1,5 @@
 # See settings documantation at src/settings.rs.
 
-debug = false
-
 [cache.entries]
 uuid = { exp = "PT120M", exp_empty = "PT5M" }
 profile = { exp = "PT10M", exp_empty = "PT5M" }
@@ -32,6 +30,7 @@ head = { cap = 300, ttl = "PT1H", ttl_empty = "PT30M", tti = "PT1H", tti_empty =
 
 [sentry]
 enabled = false
+debug = false
 address = "https://key@sentry.io/42" # update if enabled
 environment = "staging"
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -1,6 +1,6 @@
 # See settings documantation at src/settings.rs.
 
-unsigned_profile = true
+signed_profiles = false
 
 [cache.entries]
 uuid = { exp = "PT120M", exp_empty = "PT5M" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,20 +70,20 @@ where
 pub async fn start(settings: Arc<Settings>) -> Result<(), Box<dyn std::error::Error>> {
     info!("starting xenos …");
 
-    // build chaining cache with selected caches
+    // build cache with selected cache levels
     // it consists of a local and remote cache
-    info!("building chaining cache from caches");
+    info!("building multi-level cache");
     let cache = Cache::new(settings.cache.entries.clone())
-        // the top most layer is a local (in-memory) cache, in this case a moka cache
+        // the top most level is a local (in-memory) cache, in this case a moka cache
         .add_level(settings.cache.moka.enabled, || async {
-            info!("adding moka cache to chaining cache");
+            info!("adding moka cache level");
             let cache = MokaCache::new(settings.cache.moka.clone());
             Ok::<Arc<dyn CacheLevel>, Box<dyn std::error::Error>>(Arc::new(cache))
         })
         .await?
-        // the next layer is a remote cache, in this case a redis cache
+        // the next level is a remote cache, in this case a redis cache
         .add_level(settings.cache.redis.enabled, || async {
-            info!("adding redis cache to chaining cache");
+            info!("adding redis cache level");
             let cs = &settings.cache;
             let redis_client = redis::Client::open(cs.redis.address.clone())?;
             let redis_manager = redis_client.get_connection_manager().await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ where
 /// [tracing] was configured beforehand. It blocks until a shutdown signal is received (graceful shutdown).
 #[tracing::instrument(skip(settings))]
 pub async fn start(settings: Arc<Settings>) -> Result<(), Box<dyn std::error::Error>> {
-    info!(debug = settings.debug, "starting xenos …");
+    info!("starting xenos …");
 
     // build chaining cache with selected caches
     // it consists of a local and remote cache

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .enabled
             .then_some(settings.sentry.address.clone()),
         sentry::ClientOptions {
-            debug: settings.debug,
+            debug: settings.sentry.debug,
             release: sentry::release_name!(),
             environment: Some(Owned(settings.sentry.environment.clone())),
             ..sentry::ClientOptions::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow::Owned;
 use std::sync::Arc;
-use tracing::{info, Level};
+use tracing::info;
 
 use tracing_subscriber::prelude::*;
 use xenos::settings::Settings;
@@ -28,8 +28,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // initialize logging with sentry hook
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::fmt::Layer::new()
-                .with_writer(std::io::stdout.with_max_level(Level::INFO)),
+            tracing_subscriber::fmt::layer()
+                .compact()
+                .with_filter(settings.logging.level),
         )
         .with(sentry_tracing::layer())
         .init();

--- a/src/mojang/api.rs
+++ b/src/mojang/api.rs
@@ -102,13 +102,13 @@ impl Mojang for MojangApi {
     }
 
     #[tracing::instrument(skip(self))]
-    async fn fetch_profile(&self, uuid: &Uuid, unsigned: bool) -> Result<Profile, XenosError> {
+    async fn fetch_profile(&self, uuid: &Uuid, signed: bool) -> Result<Profile, XenosError> {
         let response = monitor_reqwest("profile", || {
             HTTP_CLIENT
                 .get(format!(
                     "https://sessionserver.mojang.com/session/minecraft/profile/{}?unsigned={}",
                     uuid.simple(),
-                    unsigned,
+                    !signed,
                 ))
                 .send()
         })

--- a/src/mojang/api.rs
+++ b/src/mojang/api.rs
@@ -102,12 +102,13 @@ impl Mojang for MojangApi {
     }
 
     #[tracing::instrument(skip(self))]
-    async fn fetch_profile(&self, uuid: &Uuid) -> Result<Profile, XenosError> {
+    async fn fetch_profile(&self, uuid: &Uuid, unsigned: bool) -> Result<Profile, XenosError> {
         let response = monitor_reqwest("profile", || {
             HTTP_CLIENT
                 .get(format!(
-                    "https://sessionserver.mojang.com/session/minecraft/profile/{}",
-                    uuid.simple()
+                    "https://sessionserver.mojang.com/session/minecraft/profile/{}?unsigned={}",
+                    uuid.simple(),
+                    unsigned,
                 ))
                 .send()
         })

--- a/src/mojang/mod.rs
+++ b/src/mojang/mod.rs
@@ -193,7 +193,7 @@ pub fn build_skin_head(skin_bytes: &[u8], overlay: bool) -> Result<Vec<u8>, Imag
 #[async_trait]
 pub trait Mojang: Send + Sync {
     async fn fetch_uuids(&self, usernames: &[String]) -> Result<Vec<UsernameResolved>, XenosError>;
-    async fn fetch_profile(&self, uuid: &Uuid, unsigned: bool) -> Result<Profile, XenosError>;
+    async fn fetch_profile(&self, uuid: &Uuid, signed: bool) -> Result<Profile, XenosError>;
     async fn fetch_image_bytes(&self, url: String, resource_tag: &str)
         -> Result<Bytes, XenosError>;
 }

--- a/src/mojang/mod.rs
+++ b/src/mojang/mod.rs
@@ -169,7 +169,7 @@ pub fn is_steve(uuid: &Uuid) -> bool {
 /// Builds the head image bytes from a skin. Expects a valid skin.
 #[tracing::instrument(skip(skin_bytes))]
 pub fn build_skin_head(skin_bytes: &[u8], overlay: bool) -> Result<Vec<u8>, ImageError> {
-    let skin_img = image::load_from_memory_with_format(skin_bytes, image::ImageFormat::Png)?;
+    let skin_img = image::load_from_memory_with_format(skin_bytes, ImageFormat::Png)?;
     let mut head_img = skin_img.view(8, 8, 8, 8).to_image();
 
     if overlay {
@@ -193,7 +193,7 @@ pub fn build_skin_head(skin_bytes: &[u8], overlay: bool) -> Result<Vec<u8>, Imag
 #[async_trait]
 pub trait Mojang: Send + Sync {
     async fn fetch_uuids(&self, usernames: &[String]) -> Result<Vec<UsernameResolved>, XenosError>;
-    async fn fetch_profile(&self, uuid: &Uuid) -> Result<Profile, XenosError>;
+    async fn fetch_profile(&self, uuid: &Uuid, unsigned: bool) -> Result<Profile, XenosError>;
     async fn fetch_image_bytes(&self, url: String, resource_tag: &str)
         -> Result<Bytes, XenosError>;
 }

--- a/src/mojang/testing.rs
+++ b/src/mojang/testing.rs
@@ -148,7 +148,7 @@ impl<'a> Mojang for MojangTestingApi<'a> {
         Ok(uuids)
     }
 
-    async fn fetch_profile(&self, uuid: &Uuid) -> Result<Profile, XenosError> {
+    async fn fetch_profile(&self, uuid: &Uuid, _unsigned: bool) -> Result<Profile, XenosError> {
         self.profiles.get(uuid).cloned().ok_or(XenosError::NotFound)
     }
 

--- a/src/mojang/testing.rs
+++ b/src/mojang/testing.rs
@@ -148,7 +148,7 @@ impl<'a> Mojang for MojangTestingApi<'a> {
         Ok(uuids)
     }
 
-    async fn fetch_profile(&self, uuid: &Uuid, _unsigned: bool) -> Result<Profile, XenosError> {
+    async fn fetch_profile(&self, uuid: &Uuid, _signed: bool) -> Result<Profile, XenosError> {
         self.profiles.get(uuid).cloned().ok_or(XenosError::NotFound)
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -218,7 +218,11 @@ impl Service {
         };
 
         // try to fetch from mojang and update cache
-        match self.mojang.fetch_profile(uuid).await {
+        match self
+            .mojang
+            .fetch_profile(uuid, self.settings.unsigned_profile)
+            .await
+        {
             Ok(profile) => {
                 let dated = self.cache.set_profile(*uuid, Some(profile)).await.unwrap();
                 Ok(dated)

--- a/src/service.rs
+++ b/src/service.rs
@@ -220,7 +220,7 @@ impl Service {
         // try to fetch from mojang and update cache
         match self
             .mojang
-            .fetch_profile(uuid, self.settings.unsigned_profile)
+            .fetch_profile(uuid, self.settings.signed_profiles)
             .await
         {
             Ok(profile) => {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -215,6 +215,9 @@ pub struct Sentry {
     /// Whether sentry should be enabled.
     pub enabled: bool,
 
+    /// Whether sentry should have debug enabled.
+    pub debug: bool,
+
     /// The address of the sentry instance. This can either be the official sentry or a self-hosted instance.
     /// The address has to bes event if sentry is disabled. In that case, the address can be any non-nil value.
     pub address: String,
@@ -238,10 +241,6 @@ pub struct Logging {
 /// with status ok.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Settings {
-    /// Whether the application should be in debug mode. Application components may provide additional
-    /// functionalities or outputs in debug mode.
-    pub debug: bool,
-
     /// The logging configuration.
     pub logging: Logging,
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -48,8 +48,7 @@ use serde::{Deserialize, Deserializer};
 use tracing::metadata::LevelFilter;
 
 /// [Cache] hold the service cache configurations. The different caches are accumulated by the
-/// [ChainingCache](crate::cache::chaining::ChainingCache). If no cache is `enabled`, caching is
-/// effectively disabled.
+/// [Cache](crate::cache::Cache). If no cache is `enabled`, caching is effectively disabled.
 ///
 /// In general, there should always be a local cache (e.g. [moka](MokaCache)) enabled and optionally
 /// a remote cache (e.g. [redis](RedisCache)).
@@ -68,9 +67,10 @@ pub struct Cache {
 /// supports [MokaCacheEntry] `ttl` and `tti` and `cap` per cache entry type.
 #[derive(Debug, Clone, Deserialize)]
 pub struct MokaCache {
-    /// Whether the cache should be used by the [ChainingCache](crate::cache::chaining::ChainingCache).
+    /// Whether the cache level should be used.
     pub enabled: bool,
 
+    /// The configuration for the cache entries.
     pub entries: CacheEntries<MokaCacheEntry>,
 }
 
@@ -78,13 +78,14 @@ pub struct MokaCache {
 /// [RedisCacheEntry] `ttl` per cache entry type but not `tti` and `cap`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct RedisCache {
-    /// Whether the cache should be used by the [ChainingCache](crate::cache::chaining::ChainingCache).
+    /// Whether the cache level should be used.
     pub enabled: bool,
 
     /// The address of the redis instance (e.g. `redis://username:password@example.com/0`). Only used
     /// if redis is enabled.
     pub address: String,
 
+    /// The configuration for the cache entries.
     pub entries: CacheEntries<RedisCacheEntry>,
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -241,6 +241,9 @@ pub struct Logging {
 /// with status ok.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Settings {
+    /// Whether the profiles should be requested with a signature.
+    pub unsigned_profile: bool,
+
     /// The logging configuration.
     pub logging: Logging,
 

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -242,7 +242,7 @@ pub struct Logging {
 #[derive(Debug, Clone, Deserialize)]
 pub struct Settings {
     /// Whether the profiles should be requested with a signature.
-    pub unsigned_profile: bool,
+    pub signed_profiles: bool,
 
     /// The logging configuration.
     pub logging: Logging,

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -37,14 +37,17 @@
 //! let settings: Settings = Settings::new()?;
 //! ```
 
+mod parser;
+
+use crate::settings::parser::parse_duration;
+use crate::settings::parser::parse_level_filter;
+
 use std::env;
 use std::net::SocketAddr;
-use std::str::FromStr;
 use std::time::Duration;
 
 use config::{Config, ConfigError, Environment, File};
-use serde::de::Unexpected;
-use serde::{Deserialize, Deserializer};
+use serde::Deserialize;
 use tracing::metadata::LevelFilter;
 
 /// [Cache] hold the service cache configurations. The different caches are accumulated by the
@@ -284,20 +287,4 @@ impl Settings {
         // you can deserialize (and thus freeze) the entire configuration as
         s.try_deserialize()
     }
-}
-
-/// Deserializer that parses an [iso8601] duration string to a [Duration]. E.g. `PT1M` is a duration
-/// of one minute.
-pub fn parse_duration<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Duration, D::Error> {
-    let iso: iso8601::Duration = Deserialize::deserialize(deserializer)?;
-    Ok(Duration::from(iso))
-}
-
-/// Deserializer for [LevelFilter] from string. E.g. `info`.
-pub fn parse_level_filter<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> Result<LevelFilter, D::Error> {
-    let level: String = Deserialize::deserialize(deserializer)?;
-    LevelFilter::from_str(&level)
-        .map_err(|_| serde::de::Error::invalid_value(Unexpected::Str(&level), &"log level string"))
 }

--- a/src/settings/parser.rs
+++ b/src/settings/parser.rs
@@ -1,0 +1,89 @@
+use serde::de::{Error, Unexpected, Visitor};
+use serde::Deserializer;
+use std::fmt;
+use std::str::FromStr;
+use std::time::Duration;
+use tracing::level_filters::LevelFilter;
+
+/// Deserializer for [LevelFilter] from string. E.g. `info`.
+pub fn parse_level_filter<'de, D>(deserializer: D) -> Result<LevelFilter, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct LevelFilterVisitor;
+
+    impl<'de> Visitor<'de> for LevelFilterVisitor {
+        type Value = LevelFilter;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            write!(formatter, "a log level name or number")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<LevelFilter, E>
+        where
+            E: Error,
+        {
+            match LevelFilter::from_str(value) {
+                Ok(filter) => Ok(filter),
+                Err(_) => Err(Error::invalid_value(
+                    Unexpected::Str(value),
+                    &"log level string or number",
+                )),
+            }
+        }
+    }
+
+    deserializer.deserialize_str(LevelFilterVisitor)
+}
+
+/// Deserializer that parses an [iso8601] duration string or number of seconds to a [Duration].
+/// E.g. `PT1M` or `60` is a duration of one minute.
+pub fn parse_duration<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct DurationVisitor;
+
+    impl<'de> Visitor<'de> for DurationVisitor {
+        type Value = Duration;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            write!(formatter, "an iso duration or number of seconds")
+        }
+
+        fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+        where
+            E: Error,
+        {
+            match u64::try_from(v) {
+                Ok(u) => self.visit_u64(u),
+                Err(_) => Err(Error::invalid_type(
+                    Unexpected::Signed(v),
+                    &"a positive number of seconds",
+                )),
+            }
+        }
+
+        fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+        where
+            E: Error,
+        {
+            Ok(Duration::from_secs(v))
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Duration, E>
+        where
+            E: Error,
+        {
+            match iso8601::Duration::from_str(value) {
+                Ok(iso) => Ok(Duration::from(iso)),
+                Err(_) => Err(Error::invalid_value(
+                    Unexpected::Str(value),
+                    &"an iso duration",
+                )),
+            }
+        }
+    }
+
+    deserializer.deserialize_any(DurationVisitor)
+}


### PR DESCRIPTION
# Changes
- Set duration (e.g. expiry) with iso string or number (of seconds)
- allow setting config file locations from env
- allow requesting signed profiles (global setting, so independent of cache)
- allow setting log level filter

# Breaking Changes
- remove `local.toml` for `config.toml`
- embed default config at compile time
- move `debug` setting from top level to `sentry.debug` (it was only used by sentry anyway)