### PR TITLE
Use structured error logging with cause

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "xenos"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "axum 0.7.5",

--- a/src/mojang/mod.rs
+++ b/src/mojang/mod.rs
@@ -215,5 +215,5 @@ pub fn build_skin_head(skin_bytes: &[u8], overlay: bool) -> Result<Vec<u8>, Imag
 pub trait Mojang: Send + Sync {
     async fn fetch_uuids(&self, usernames: &[String]) -> Result<Vec<UsernameResolved>, ApiError>;
     async fn fetch_profile(&self, uuid: &Uuid, signed: bool) -> Result<Profile, ApiError>;
-    async fn fetch_image_bytes(&self, url: String, resource_tag: &str) -> Result<Bytes, ApiError>;
+    async fn fetch_bytes(&self, url: String, resource_tag: &str) -> Result<Bytes, ApiError>;
 }

--- a/src/mojang/testing.rs
+++ b/src/mojang/testing.rs
@@ -151,7 +151,7 @@ impl<'a> Mojang for MojangTestingApi<'a> {
         self.profiles.get(uuid).cloned().ok_or(NotFound)
     }
 
-    async fn fetch_image_bytes(&self, url: String, _: &str) -> Result<Bytes, ApiError> {
+    async fn fetch_bytes(&self, url: String, _: &str) -> Result<Bytes, ApiError> {
         self.images.get(&url).cloned().cloned().ok_or(NotFound)
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -278,7 +278,7 @@ impl Service {
             .unwrap_or(CLASSIC_MODEL.to_string());
 
         // try to fetch from mojang and update cache
-        match self.mojang.fetch_image_bytes(textures.url, "skin").await {
+        match self.mojang.fetch_bytes(textures.url, "skin").await {
             Ok(skin_bytes) => {
                 let skin = SkinData {
                     bytes: skin_bytes.to_vec(),
@@ -331,7 +331,7 @@ impl Service {
         };
 
         // try to fetch from mojang and update cache
-        match self.mojang.fetch_image_bytes(textures.url, "cape").await {
+        match self.mojang.fetch_bytes(textures.url, "cape").await {
             Ok(cape_bytes) => {
                 let cape = CapeData {
                     bytes: cape_bytes.to_vec(),


### PR DESCRIPTION
# Changes

- rename fetch_image_bytes to fetch_bytes
- use structured logging with error cause

Previously, dns errors and the like would only show a generic error. Now the log includes the source(s) indicating, for example, the dns error and message.