### PR TITLE
Ensure that openssl is not required

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
       run: cargo install clippy-sarif sarif-fmt
 
     - name: Check OpenSSL
-      run: "! cargo tree -i sentry 2> /dev/null"
+      run: (! cargo tree -i sentry 2> /dev/null)
 
     - name: Build with cargo
       run: cargo build --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,9 @@ jobs:
     - name: Check format
       run: cargo fmt --check
 
+    - name: Check OpenSSL
+      run: cargo tree -i sentry > /dev/null 2>&1; test $? -eq 101
+
     - name: Perform linting
       run:
         cargo clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
       run: cargo install clippy-sarif sarif-fmt
 
     - name: Check OpenSSL
-      run: cargo tree -i openssl 2> /dev/null; test $? -eq 101
+      run: ! cargo tree -i sentry 2> /dev/null
 
     - name: Build with cargo
       run: cargo build --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
       run: cargo install clippy-sarif sarif-fmt
 
     - name: Check OpenSSL
-      run: (! cargo tree -i sentry 2> /dev/null)
+      run: (! cargo tree -i openssl 2> /dev/null)
 
     - name: Build with cargo
       run: cargo build --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
       run: cargo install clippy-sarif sarif-fmt
 
     - name: Check OpenSSL
-      run: ! cargo tree -i sentry 2> /dev/null
+      run: "! cargo tree -i sentry 2> /dev/null"
 
     - name: Build with cargo
       run: cargo build --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
       run: cargo install clippy-sarif sarif-fmt
 
     - name: Check OpenSSL
-      run: cargo tree -i sentry 2> /dev/null; test $? -eq 101
+      run: cargo tree -i openssl 2> /dev/null; test $? -eq 101
 
     - name: Build with cargo
       run: cargo build --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,9 @@ jobs:
     - name: Install required cargo
       run: cargo install clippy-sarif sarif-fmt
 
+    - name: Check OpenSSL
+      run: cargo tree -i sentry 2> /dev/null; test $? -eq 101
+
     - name: Build with cargo
       run: cargo build --verbose
 
@@ -43,9 +46,6 @@ jobs:
 
     - name: Check format
       run: cargo fmt --check
-
-    - name: Check OpenSSL
-      run: cargo tree -i sentry > /dev/null 2>&1; test $? -eq 101
 
     - name: Perform linting
       run:


### PR DESCRIPTION
# Changes

- ensure that openssl is not required by any crate

OpenSSL is not part of the docker image. As such it cannot be used by any crate. We check this by verifying, that the openssl crate is not part of the tree.