### PR TITLE
Fix UUID batch request for invalid usernames

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["metrics", "metrics/metrics-macros"]
 [package]
 name = "xenos"
 description = "Minecraft Profile Information Proxy"
-version = "0.6.0"
+version = "0.6.1"
 authors = [
     "Joshua Dean Küpper <admin@joshua-kuepper.de>",
     "Paul Wagner <contact@paulwagner.dev>"

--- a/config/default.toml
+++ b/config/default.toml
@@ -10,7 +10,6 @@ cape = { exp = "PT10M", exp_empty = "PT5M" }
 head = { exp = "PT10M", exp_empty = "PT5M" }
 
 [cache.redis]
-enabled = false
 address = "redis://username:password@example.com/0" # update if enabled
 
 [cache.redis.entries]
@@ -19,9 +18,6 @@ profile = { ttl = "P3D", ttl_empty = "P1D" }
 skin = { ttl = "P3D", ttl_empty = "P1D" }
 cape = { ttl = "P3D", ttl_empty = "P1D" }
 head = { ttl = "P3D", ttl_empty = "P1D" }
-
-[cache.moka]
-enabled = false
 
 [cache.moka.entries]
 uuid = { cap = 500, ttl = "PT1H", ttl_empty = "PT30M", tti = "PT1H", tti_empty = "PT30M" }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -361,7 +361,6 @@ mod test {
             tti_empty: Duration::from_secs(100),
         };
         settings::MokaCache {
-            enabled: false,
             entries: CacheEntries {
                 uuid: entry.clone(),
                 profile: entry.clone(),

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -69,9 +69,6 @@ pub struct Cache {
 /// supports [MokaCacheEntry] `ttl` and `tti` and `cap` per cache entry type.
 #[derive(Debug, Clone, Deserialize)]
 pub struct MokaCache {
-    /// Whether the cache level should be used.
-    pub enabled: bool,
-
     /// The configuration for the cache entries.
     pub entries: CacheEntries<MokaCacheEntry>,
 }
@@ -80,9 +77,6 @@ pub struct MokaCache {
 /// [RedisCacheEntry] `ttl` per cache entry type but not `tti` and `cap`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct RedisCache {
-    /// Whether the cache level should be used.
-    pub enabled: bool,
-
     /// The address of the redis instance (e.g. `redis://username:password@example.com/0`). Only used
     /// if redis is enabled.
     pub address: String,


### PR DESCRIPTION
The UUID batch request now uses a different approach to check if all items were cached.

# Changes
- fix batch request for invalid usernames
- remove deprecated settings