### PR TITLE
Add support for per-request signed profile requests

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -1,7 +1,5 @@
 # See config documantation at src/config.rs.
 
-signed_profiles = false
-
 [cache.entries]
 uuid = { exp = "PT120M", exp_empty = "PT5M" }
 profile = { exp = "PT10M", exp_empty = "PT5M" }

--- a/proto/profile.proto
+++ b/proto/profile.proto
@@ -57,6 +57,9 @@ message UuidsResponse {
 message ProfileRequest {
     // The UUID in simple or hyphenated form whose Minecraft Profile should be queried.
     string uuid = 1;
+    // Whether the response should omit the Yggdrasil signatures on profile properties. Defaults to true (unsigned).
+    // Signed requests are always fetched live and are not served from cache.
+    optional bool unsigned = 2;
 }
 
 // ProfileProperty is a single property of a Minecraft Profile, that is possibly signed.

--- a/src/config.rs
+++ b/src/config.rs
@@ -229,8 +229,6 @@ pub struct Sentry {
 /// with status ok.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Config {
-    /// Whether the profiles should be requested with a signature.
-    pub signed_profiles: bool,
     /// The service cache configuration.
     pub cache: Cache,
 

--- a/src/grpc_services.rs
+++ b/src/grpc_services.rs
@@ -87,8 +87,10 @@ where
                 handler: "grpc",
             })
             .inc();
-        let uuid = Uuid::try_parse(&request.into_inner().uuid).map_err(UuidError)?;
-        let profile = self.service.get_profile(&uuid).await?;
+        let inner = request.into_inner();
+        let uuid = Uuid::try_parse(&inner.uuid).map_err(UuidError)?;
+        let unsigned = inner.unsigned.unwrap_or(true);
+        let profile = self.service.get_profile(&uuid, unsigned).await?;
         Ok(Response::new(profile.into()))
     }
 

--- a/src/rest_services.rs
+++ b/src/rest_services.rs
@@ -128,7 +128,8 @@ where
         })
         .inc();
     let uuid = Uuid::try_parse(&payload.uuid)?;
-    Ok(Json(service.get_profile(&uuid).await?.into()))
+    let unsigned = payload.unsigned.unwrap_or(true);
+    Ok(Json(service.get_profile(&uuid, unsigned).await?.into()))
 }
 
 /// An [axum] handler for [SkinRequest] rest gateway.

--- a/src/service.rs
+++ b/src/service.rs
@@ -218,41 +218,49 @@ where
 
     /// Gets the profile for an uuid from cache or mojang.
     ///
-    /// If `unsigned` is `false`, the request is always fetched live from Mojang (no cache read or write)
-    /// so that the Yggdrasil signatures are included and are guaranteed to be fresh.
+    /// If `unsigned` is `false`, the request is always fetched live from Mojang so that the Yggdrasil
+    /// signatures are included and guaranteed to be fresh. The result is also written to cache so that
+    /// subsequent unsigned requests benefit from it.
     #[tracing::instrument(skip(self))]
     #[metrics::metrics(metric = "service", labels(request_type = "profile"), handler = metrics_age_handler)]
-    pub async fn get_profile(&self, uuid: &Uuid, unsigned: bool) -> Result<Dated<ProfileData>, ServiceError> {
-        if unsigned {
-            // try to get from the cache
-            let cached = self.cache.get_profile(uuid).await;
-            let fallback = match cached {
-                Hit(entry) => return entry.some_or(NotFound),
-                Expired(entry) => Some(entry),
-                Miss => None,
-            };
-
-            // try to fetch from mojang and update the cache
-            match self.mojang.fetch_profile(uuid, false).await {
+    pub async fn get_profile(
+        &self,
+        uuid: &Uuid,
+        unsigned: bool,
+    ) -> Result<Dated<ProfileData>, ServiceError> {
+        // signed requests are always fetched live; result is also written to cache for unsigned consumers
+        if !unsigned {
+            return match self.mojang.fetch_profile(uuid, true).await {
                 Ok(profile) => {
-                    let dated = self.cache.set_profile(uuid, Some(profile)).await.unwrap();
-                    Ok(dated)
+                    self.cache.set_profile(uuid, Some(profile.clone())).await;
+                    Ok(Dated::from(profile))
                 }
-                Err(ApiError::NotFound) => {
-                    self.cache.set_profile(uuid, None).await;
-                    Err(NotFound)
-                }
-                Err(ApiError::Unavailable) => fallback
-                    .ok_or(Unavailable)
-                    .and_then(|entry| entry.some_or(NotFound)),
-            }
-        } else {
-            // signed requests are always fetched live, never cached
-            match self.mojang.fetch_profile(uuid, true).await {
-                Ok(profile) => Ok(Dated::from(profile)),
                 Err(ApiError::NotFound) => Err(NotFound),
                 Err(ApiError::Unavailable) => Err(Unavailable),
+            };
+        }
+
+        // try to get from the cache
+        let cached = self.cache.get_profile(uuid).await;
+        let fallback = match cached {
+            Hit(entry) => return entry.some_or(NotFound),
+            Expired(entry) => Some(entry),
+            Miss => None,
+        };
+
+        // try to fetch from mojang and update the cache
+        match self.mojang.fetch_profile(uuid, false).await {
+            Ok(profile) => {
+                let dated = self.cache.set_profile(uuid, Some(profile)).await.unwrap();
+                Ok(dated)
             }
+            Err(ApiError::NotFound) => {
+                self.cache.set_profile(uuid, None).await;
+                Err(NotFound)
+            }
+            Err(ApiError::Unavailable) => fallback
+                .ok_or(Unavailable)
+                .and_then(|entry| entry.some_or(NotFound)),
         }
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -217,34 +217,42 @@ where
     }
 
     /// Gets the profile for an uuid from cache or mojang.
+    ///
+    /// If `unsigned` is `false`, the request is always fetched live from Mojang (no cache read or write)
+    /// so that the Yggdrasil signatures are included and are guaranteed to be fresh.
     #[tracing::instrument(skip(self))]
     #[metrics::metrics(metric = "service", labels(request_type = "profile"), handler = metrics_age_handler)]
-    pub async fn get_profile(&self, uuid: &Uuid) -> Result<Dated<ProfileData>, ServiceError> {
-        // try to get from the cache
-        let cached = self.cache.get_profile(uuid).await;
-        let fallback = match cached {
-            Hit(entry) => return entry.some_or(NotFound),
-            Expired(entry) => Some(entry),
-            Miss => None,
-        };
+    pub async fn get_profile(&self, uuid: &Uuid, unsigned: bool) -> Result<Dated<ProfileData>, ServiceError> {
+        if unsigned {
+            // try to get from the cache
+            let cached = self.cache.get_profile(uuid).await;
+            let fallback = match cached {
+                Hit(entry) => return entry.some_or(NotFound),
+                Expired(entry) => Some(entry),
+                Miss => None,
+            };
 
-        // try to fetch from mojang and update the cache
-        match self
-            .mojang
-            .fetch_profile(uuid, self.config.signed_profiles)
-            .await
-        {
-            Ok(profile) => {
-                let dated = self.cache.set_profile(uuid, Some(profile)).await.unwrap();
-                Ok(dated)
+            // try to fetch from mojang and update the cache
+            match self.mojang.fetch_profile(uuid, false).await {
+                Ok(profile) => {
+                    let dated = self.cache.set_profile(uuid, Some(profile)).await.unwrap();
+                    Ok(dated)
+                }
+                Err(ApiError::NotFound) => {
+                    self.cache.set_profile(uuid, None).await;
+                    Err(NotFound)
+                }
+                Err(ApiError::Unavailable) => fallback
+                    .ok_or(Unavailable)
+                    .and_then(|entry| entry.some_or(NotFound)),
             }
-            Err(ApiError::NotFound) => {
-                self.cache.set_profile(uuid, None).await;
-                Err(NotFound)
+        } else {
+            // signed requests are always fetched live, never cached
+            match self.mojang.fetch_profile(uuid, true).await {
+                Ok(profile) => Ok(Dated::from(profile)),
+                Err(ApiError::NotFound) => Err(NotFound),
+                Err(ApiError::Unavailable) => Err(Unavailable),
             }
-            Err(ApiError::Unavailable) => fallback
-                .ok_or(Unavailable)
-                .and_then(|entry| entry.some_or(NotFound)),
         }
     }
 
@@ -261,7 +269,7 @@ where
         };
 
         // try to get a profile
-        let profile = match self.get_profile(uuid).await {
+        let profile = match self.get_profile(uuid, true).await {
             Ok(profile) => profile.data,
             Err(Unavailable) => {
                 return fallback
@@ -316,7 +324,7 @@ where
         };
 
         // try to get the profile
-        let profile = match self.get_profile(uuid).await {
+        let profile = match self.get_profile(uuid, true).await {
             Ok(profile) => profile.data,
             Err(Unavailable) => {
                 return fallback


### PR DESCRIPTION
I've revised the logic for requesting signed profiles and aligned them to what Mojang does in the vanilla server jar. Signed profiles should be explicitly requested and should skip the cache (as this needs the most recent, signed information). Unsigned profiles can be cached indefinitely. I've also removed the setting, always defaulting to unsigned, as there's no benefit in always requesting signed profiles.